### PR TITLE
Add Next.js frontend and admin logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+nextapp/.next/
+nextapp/node_modules/
+server

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # proxyclient
+
+This project provides a simple web proxy with a tabbed browser interface.
+The backend is now implemented in Go for better performance while the UI is built with Next.js.
+
+## Running
+
+### Backend
+
+1. Build the Go server:
+   ```bash
+   go build -o server
+   ```
+2. Start the server:
+   ```bash
+   ./server
+   ```
+
+### Frontend
+
+The Next.js app is located in `nextapp`.
+
+1. Install Node dependencies:
+   ```bash
+   cd nextapp
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open `http://localhost:3000` in your browser. Use the **New Tab** button on
+   the homepage. When a loaded page contains iframes, buttons appear allowing you to open each iframe in its own tab. The `/admin` route displays logged client information collected by the backend.
+
+## Testing
+
+Execute all tests using:
+
+```bash
+pytest
+```

--- a/nextapp/package.json
+++ b/nextapp/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "proxyclient-ui",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/nextapp/pages/admin.js
+++ b/nextapp/pages/admin.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+
+export default function Admin() {
+  const [logs, setLogs] = useState([])
+
+  useEffect(() => {
+    fetch('http://localhost:5000/logs')
+      .then(r => r.json())
+      .then(setLogs)
+  }, [])
+
+  return (
+    <div>
+      <h1>Client Logs</h1>
+      <table border="1">
+        <thead>
+          <tr>
+            <th>IP</th>
+            <th>User Agent</th>
+            <th>Path</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log, idx) => (
+            <tr key={idx}>
+              <td>{log.ip}</td>
+              <td>{log.user_agent}</td>
+              <td>{log.path}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/nextapp/pages/index.js
+++ b/nextapp/pages/index.js
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+export default function Home() {
+  const [tabs, setTabs] = useState([{ id: 1, iframes: [] }])
+  const [active, setActive] = useState(1)
+
+  const newTab = (url = '') => {
+    const id = Date.now()
+    setTabs([...tabs, { id, iframes: [] }])
+    setActive(id)
+    if (url) loadUrl(id, url)
+  }
+
+  const loadUrl = (id, directUrl) => {
+    const url = directUrl || document.getElementById(`url-${id}`).value
+    fetch('http://localhost:5000/fetch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    })
+      .then(r => r.text())
+      .then(html => {
+        document.getElementById(`frame-${id}`).srcdoc = html
+        const doc = new DOMParser().parseFromString(html, 'text/html')
+        const frames = Array.from(doc.querySelectorAll('iframe[src]')).map(f => f.getAttribute('src'))
+        setTabs(tabs => tabs.map(t => t.id === id ? { ...t, iframes: frames } : t))
+      })
+  }
+
+  return (
+    <div>
+      <button onClick={newTab}>New Tab</button>
+      <div>
+        {tabs.map(t => (
+          <button key={t.id} onClick={() => setActive(t.id)}>Tab {t.id}</button>
+        ))}
+      </div>
+      {tabs.map(tab => (
+        <div key={tab.id} style={{ display: active === tab.id ? 'block' : 'none' }}>
+          <input id={`url-${tab.id}`} type="text" size={40} placeholder="Enter URL" />
+          <button onClick={() => loadUrl(tab.id)}>Go</button>
+          <div>
+            {tab.iframes.map(src => (
+              <button key={src} onClick={() => newTab(src)}>Open {src}</button>
+            ))}
+          </div>
+          <iframe id={`frame-${tab.id}`} style={{ width: '100%', height: '80vh' }} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pytest

--- a/server.go
+++ b/server.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+    "encoding/json"
+    "io"
+    "log"
+    "net/http"
+    "sync"
+    "time"
+)
+
+type LogEntry struct {
+    IP        string `json:"ip"`
+    UserAgent string `json:"user_agent"`
+    Path      string `json:"path"`
+}
+
+var (
+    logs []LogEntry
+    mu   sync.Mutex
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", indexHandler)
+    mux.HandleFunc("/fetch", fetchHandler)
+    mux.HandleFunc("/logs", logsHandler)
+
+    handler := logMiddleware(mux)
+
+    log.Println("Server running on :5000")
+    if err := http.ListenAndServe(":5000", handler); err != nil {
+        log.Fatal(err)
+    }
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+    http.ServeFile(w, r, "static/index.html")
+}
+
+func fetchHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+    var body struct{ URL string `json:"url"` }
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.URL == "" {
+        http.Error(w, "url missing", http.StatusBadRequest)
+        return
+    }
+    client := http.Client{Timeout: 10 * time.Second}
+    resp, err := client.Get(body.URL)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+    defer resp.Body.Close()
+    for k, v := range resp.Header {
+        if len(v) > 0 && (k == "Content-Type" || k == "Content-Length") {
+            w.Header().Set(k, v[0])
+        }
+    }
+    w.WriteHeader(resp.StatusCode)
+    io.Copy(w, resp.Body)
+}
+
+func logsHandler(w http.ResponseWriter, r *http.Request) {
+    mu.Lock()
+    defer mu.Unlock()
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(logs)
+}
+
+func logMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        next.ServeHTTP(w, r)
+        mu.Lock()
+        logs = append(logs, LogEntry{
+            IP:        r.RemoteAddr,
+            UserAgent: r.UserAgent(),
+            Path:      r.URL.Path,
+        })
+        mu.Unlock()
+        w.Header().Set("Access-Control-Allow-Origin", "*")
+        w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+    })
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Proxy Browser</title>
+  <style>
+    body { font-family: sans-serif; }
+    .tab { display: none; }
+    .tab.active { display: block; }
+    iframe { width: 100%; height: 80vh; border: 1px solid #ccc; }
+  </style>
+</head>
+<body>
+  <div id="tabs"></div>
+  <button onclick="newTab()">New Tab</button>
+<script>
+let tabCount = 0;
+function newTab(url = '') {
+  const id = 'tab' + (++tabCount);
+  const div = document.createElement('div');
+  div.className = 'tab';
+  div.id = id;
+  div.innerHTML = `<input type="text" id="${id}-url" placeholder="Enter URL" value="${url}" size="40">
+    <button onclick="loadUrl('${id}')">Go</button>
+    <div id="${id}-iframes"></div>
+    <iframe id="${id}-frame"></iframe>`;
+  document.getElementById('tabs').appendChild(div);
+  setActive(id);
+  if (url) loadUrl(id, url);
+}
+function setActive(id) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+}
+function loadUrl(id, directUrl) {
+  const url = directUrl || document.getElementById(id + '-url').value;
+  fetch('/fetch', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({url})
+  }).then(r => r.text())
+    .then(html => {
+      document.getElementById(id + '-frame').srcdoc = html;
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const buttons = document.getElementById(id + '-iframes');
+      buttons.innerHTML = '';
+      doc.querySelectorAll('iframe[src]').forEach(f => {
+        const src = f.getAttribute('src');
+        const b = document.createElement('button');
+        b.textContent = 'Open ' + src;
+        b.onclick = () => newTab(src);
+        buttons.appendChild(b);
+      });
+    });
+}
+</script>
+</body>
+</html>

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,52 @@
+import subprocess
+import time
+import requests
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import pytest
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(b'<html><title>Example Domain</title></html>')
+
+@pytest.fixture(scope="module")
+def go_server():
+    proc = subprocess.Popen(["go", "run", "server.go"], cwd=str(Path(__file__).resolve().parents[1]), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    for _ in range(20):
+        try:
+            requests.get("http://localhost:5000/logs")
+            break
+        except Exception:
+            time.sleep(0.1)
+    yield
+    proc.terminate()
+    proc.wait()
+
+@pytest.fixture
+def remote_server():
+    httpd = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield f"http://localhost:{httpd.server_address[1]}"
+    httpd.shutdown()
+    thread.join()
+
+
+def test_fetch_example(go_server, remote_server):
+    resp = requests.post("http://localhost:5000/fetch", json={"url": remote_server})
+    assert resp.status_code == 200
+    assert "Example Domain" in resp.text
+
+
+def test_logs_recorded(go_server, remote_server):
+    headers = {"User-Agent": "test-agent"}
+    requests.post("http://localhost:5000/fetch", json={"url": remote_server}, headers=headers)
+    resp = requests.get("http://localhost:5000/logs")
+    assert resp.status_code == 200
+    logs = resp.json()
+    assert any(log.get("user_agent") == "test-agent" for log in logs)


### PR DESCRIPTION
## Summary
- create Next.js app in `nextapp`
- log requests on the Go backend and expose `/logs`
- add admin page to view logs
- document running backend and frontend
- update tests for logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684577a20c4083238663e0b69e630aad